### PR TITLE
Fix comment stripping

### DIFF
--- a/swift_domain/indexer.py
+++ b/swift_domain/indexer.py
@@ -68,7 +68,7 @@ def get_doc_block(content, line):
     for i in range(line, 0, -1):
         l = content[i].strip()
         if l.startswith('///'):
-            converted = l[4:].rstrip()
+            converted = l[3:].rstrip()
             converted = converted.replace('`', '``')
             doc_block.insert(0, converted)
             continue


### PR DESCRIPTION
I sometimes comment with the style

```
///This is my documentation
```

rather than

```
/// This is my documentation
```

Currently, anarchy-sphinx truncates the former to

```
his is my documentation
```

which is not correct.  Fix that trimming.
