### PR TITLE
Make reference typo suggestions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,7 @@ setup(
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',
     ],
+    install_requires=[
+        'fuzzywuzzy'
+    ]
 )

--- a/swift_domain/autodoc.py
+++ b/swift_domain/autodoc.py
@@ -36,9 +36,15 @@ class SwiftAutoDocumenter(Documenter):
             emit_warning = False
 
         if emit_warning:
+            #find best match
+            best = file_index.find_fuzz(self.name)
+            if best:
+                err = 'can not find "%s" in any Swift file.  Did you mean "%s"?' % (self.name,best[0])
+            else:
+                err = 'can not find "%s" in any Swift file.  No Swift symbols were indexed.' % self.name
             self.env.warn(
                 self.env.docname,
-                'can not find "%s" in any Swift file!' % self.name)
+                err)
 
     def document(self, item, indent=''):
 

--- a/swift_domain/indexer.py
+++ b/swift_domain/indexer.py
@@ -2,6 +2,8 @@ import re
 import fnmatch
 import os
 from pprint import PrettyPrinter
+from fuzzywuzzy import process
+
 
 # member patterns
 func_pattern      = re.compile(r'\s*(final\s+)?(?P<scope>private\s+|public\s+|internal\s+)?(final\s+)?(?P<static>class\s|static\s+|mutating\s+)?(?P<type>func)\s+(?P<name>[a-zA-Z_][a-zA-Z0-9_]*\b)(?P<rest>[^{]*)')
@@ -207,12 +209,32 @@ class SwiftFileIndex(object):
             return args
 
         for item in index:
-            item_name = '.'.join([unpack(name_prefix), item['name']])
+            item_name = ".".join(name_prefix + [item['name']])
             if name == item_name:
                 yield item
             if len(item['children']) > 0:
                 for result in self.find(name, index=item['children'], name_prefix=[unpack(name_prefix), item['name']]):
                     yield result
+
+    def __names(self,index,name_prefix):
+        """Return all names the receiver could find."""
+        def unpack(*args):
+            return args
+        for item in index:
+            yield ".".join(name_prefix + [item['name']])
+            for child in item['children']:
+                for name in child.__names(item['children'],name_prefix=[unpack(name_prefix),item['name']]):
+                    yield name
+
+                
+
+    def find_fuzz(self,name,index=None,name_prefix=[]):
+        if not index:
+            index = self.index
+        """Returns the best match with a score like ("Foo",90)"""
+        return process.extractOne(name,self.__names(index,name_prefix))
+
+
 
     def by_file(self, index=None):
         result = {}


### PR DESCRIPTION
When linking to a Swift type that Sphinx can't find, it isn't always clear what you've done wrong (typo, namespacing issues, etc.)

The warnings now generate suggestions for what you may have meant.
