### PR TITLE
Add more specific autodoc directives

### DIFF
--- a/swift_domain/autodoc.py
+++ b/swift_domain/autodoc.py
@@ -57,6 +57,12 @@ class SwiftAutoDocumenter(Documenter):
             if len(list(filter(lambda x: x['name'] in self.options.only_with_members, item['members'].index))) <= 0:
                 return
 
+        # Don't document everything if a specific type was requested
+        if self.objtype != 'swift':
+            if item['type'] != self.objtype:
+                return
+
+
         doc = SwiftFileIndex.documentation(
             item,
             indent=self.content_indent,
@@ -99,3 +105,11 @@ class SwiftAutoDocumenter(Documenter):
         if 'recursive-members' in self.options:
             for child in item['children']:
                 self.document(child, indent=indent + self.content_indent)
+
+class ProtocolAutoDocumenter(SwiftAutoDocumenter):
+    objtype = 'protocol'
+
+class ExtensionAutoDocumenter(SwiftAutoDocumenter):
+    objtype = 'extension'
+    
+

--- a/swift_domain/swift.py
+++ b/swift_domain/swift.py
@@ -585,11 +585,13 @@ def make_index(app,*args):
     build_index(app)
 
 def setup(app):
-    from .autodoc import SwiftAutoDocumenter, build_index
+    from .autodoc import SwiftAutoDocumenter, ProtocolAutoDocumenter, ExtensionAutoDocumenter
     app.connect('builder-inited', make_index)
 
     app.override_domain(SwiftStandardDomain)
     app.add_autodocumenter(SwiftAutoDocumenter)
+    app.add_autodocumenter(ProtocolAutoDocumenter)
+    app.add_autodocumenter(ExtensionAutoDocumenter)
 
     app.add_domain(SwiftDomain)
     app.add_config_value('swift_search_path', ['../src'], 'env')


### PR DESCRIPTION
This adds two new directives, `autoprotocol` and `autoextension`.  These are like `autoswift` but for (only) protocols and extensions, respectively.

This faciliates the disambiguation of tricky cases where multiple things are named the same.  See also #6 for a similar case (that cannot be disambiguated with by type alone).

Other directives should probably be added, but these are the two I need today.
