### PR TITLE
Add swift-version of `noindex` directive

### DIFF
--- a/swift_domain/indexer.py
+++ b/swift_domain/indexer.py
@@ -289,13 +289,16 @@ class SwiftObjectIndex(object):
                                 scope = 'internal'
                     else:
                         scope = 'public'
+                    docstring = get_doc_block(content, i - 1)
+                    if "- noindex: true" in docstring:
+                        continue
                     self.index.append({
                         'scope': scope,
                         'line': i,
                         'type': match['type'].strip(),
                         'name': match['name'].strip() if match['type'] != 'init' and match['type'] != 'init?' else 'init',
                         'static': match['static'].strip() if 'static' in match and match['static'] else None,
-                        'docstring': get_doc_block(content, i - 1),
+                        'docstring': docstring,
                         'rest': match['rest'].strip() if 'rest' in match and match['rest'] else None,
                         'assoc_type': match['assoc_type'].strip() if 'assoc_type' in match and match['assoc_type'] else None,
                         'raw_value': match['raw_value'].strip() if 'raw_value' in match and match['raw_value'] else None,


### PR DESCRIPTION
Add swift-version of `noindex` directive

I have a lot of code like this:

``` swift
#if swift(>=3.0)
func foo() { /* swift 3 version of foo */}
#else
func foo() { /* swift 2 version of foo */}
#endif
```

Obviously the function should only appear once in the documentation, because in a particular library it's only declared once.  And we probably want the Swift 3 version.

There is currently no way to hide only one of these–they have the same name and so can't be addressed separately in Sphinx (e.g. via some autodoc directive).

This adds a new `- noindex: true` value to swift comments so I can specify which one should be documented and resolve this case:

``` swift
#if swift(>=3.0)
func foo() { /* swift 3 version of foo */}
#else
- noindex: true
func foo() { /* swift 2 version of foo */}
#endif
```

That way the second foo() is completely ignored by anarchy-sphinx.
