### PR TITLE
Fix various problems with generics

### DIFF
--- a/swift_domain/swift.py
+++ b/swift_domain/swift.py
@@ -213,9 +213,18 @@ class SwiftClassmember(SwiftObjectDescription):
         first_anglebracket = sig.find('<')
         first_paren = sig.find('(')
         if first_anglebracket >= 0 and first_paren > first_anglebracket:
-            split_point = sig.find('>')
+            split_point = sig.find('>')+1
         else:
             split_point = first_paren
+
+        # calculate generics
+        if first_anglebracket >= 0:
+            sp = sig[first_anglebracket:]
+            np = sp.find('>')
+            generics = sp[:np+1]
+        else:
+            generics = None
+
         method_name = sig[0:split_point]
 
         # find method specialization
@@ -274,6 +283,9 @@ class SwiftClassmember(SwiftObjectDescription):
             for p in parameters:
                 signature += p['name'] + ':'
             signature += ')'
+
+        if generics:
+            signode += addnodes.desc_addname(generics,generics)
 
         params = []
         sig = ''


### PR DESCRIPTION
- An off-by-1 error prevented any arguments from being parsed for a generic function
- Generics were just not printed (e.g. anywhere).  In particular, they seem to be excluded from the method name.  However this is problematic as the following real-world torture case shows:
  
  ``` swift
  ///Assert that two objects are equal
  ///- parameter message: A reason for failure
  public final func assert<T: Equatable>(_ a: T,  equals b: T, _ message: @autoclosure () -> String = "Assertion failed", file: String = #file, line: Int = #line) {}
  
  ///Assert that two sequences are equal
  ///- parameter message: A reason for failure
  public final func assert<T:Sequence where T.Iterator.Element: Equatable>(_ a: T,  equals b: T, _ message: @autoclosure () -> String = "Assertion failed", file: String = #file, line: Int = #line) {
  }
  
  ///Assert that two objects aren't equal
  ///- parameter message: A reason for failure
  public final func assert<T: Equatable>(_ a: T,  notEqual b: T, _ message: @autoclosure () -> String = "Assertion failed", file: String = #file, line: Int = #line) {}
  
  ///Assert that two sequences aren't equal
  ///- parameter message: A reason for failure
  public final func assert<T:Sequence where T.Iterator.Element: Equatable>(_ a: T,  notEqual b: T, _ message: @autoclosure () -> String = "Assertion failed", file: String = #file, line: Int = #line) {}
  ```
  
  These functions are distinguished solely by their generic parameters (which is fully legal in Swift) but if the generic parameters aren't listed then we can't distinguish them.
  
  The resolution to this problem is to emit a separate non-name node to contain the generic information.
