### PR TITLE
Actually take config parameters

### DIFF
--- a/swift_domain/swift.py
+++ b/swift_domain/swift.py
@@ -563,12 +563,16 @@ class SwiftDomain(Domain):
         for refname, (docname, type, signature) in _iteritems(self.data['objects']):
             yield (refname, refname, type, docname, refname, 1)
 
+def make_index(app,*args):
+    from .autodoc import build_index
+    build_index(app)
 
 def setup(app):
     from .autodoc import SwiftAutoDocumenter, build_index
+    app.connect('builder-inited', make_index)
+
     app.add_autodocumenter(SwiftAutoDocumenter)
 
     app.add_domain(SwiftDomain)
     app.add_config_value('swift_search_path', ['../src'], 'env')
     app.add_config_value('autodoc_default_flags', [], True)
-    build_index(app)


### PR DESCRIPTION
At setup time, the config parameters are not actually read.  Therefore, instead of using e.g. the `swift_search_path` that the user configured, we only use the default one.  Hope your source is in `../src`!

We now delay the indexing until the config values are actually read.  Through trial and error the `builder-inited` event seems like a good time to run the index.
