### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# You can use this to build an anarchy_sphinx docker image
+# just mount your folder to /docs and go!
+# docker run -it -v `pwd`:/docs sphinx
+
+FROM debian:latest
+
+RUN apt-get update && apt-get install python3 python3-setuptools python3-pip make -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN pip3 install sphinx_bootstrap_theme
+ADD . /anarchy_sphinx
+WORKDIR anarchy_sphinx
+RUN python3 setup.py install
+RUN mkdir /docs
+WORKDIR /docs
+ENTRYPOINT ["make","html"]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Topic :: Software Development :: Documentation',
     ],
     install_requires=[
-        'fuzzywuzzy'
+        'fuzzywuzzy',
+        'sphinx'
     ]
 )


### PR DESCRIPTION
This allows docker builds of anarchysphinx.

We need various open PRs applied to build our documentation, this is the script we are using internally to build and distribute our fork.  At the moment all our patches are PRed but not all merged, and we may need other patches for future projects as necessary.

Docker images may be useful officially as well, so sending our build/packaging process upstream for inclusion.

Also, resolves #1
