### PR TITLE
Add doc2dash support for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 
 FROM debian:latest
 
-RUN apt-get update && apt-get install python3 python3-setuptools python3-pip make -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN pip3 install sphinx_bootstrap_theme
+RUN apt-get update && apt-get install python3 python3-setuptools python3-pip libxml2-dev libxslt-dev zlib1g-dev make -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN pip3 install sphinx_bootstrap_theme doc2dash
 ADD . /anarchy_sphinx
 WORKDIR anarchy_sphinx
 RUN python3 setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ WORKDIR anarchy_sphinx
 RUN python3 setup.py install
 RUN mkdir /docs
 WORKDIR /docs
-ENTRYPOINT ["make","html"]
+CMD ["make","html"]

--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,8 @@ Add the following to your sphinx ``Makefile``. You will need the pip package
 On top in the variable declaration section::
 
     PROJECT_NAME=myproject
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
 
 In the helptext section::
 


### PR DESCRIPTION
Add various dependencies and whatnot to support Dash building from our docker image

Update README to indicate python should be forced into UTF-8 mode.  This is required for some reason, who understands Python unicode anyway?
