### PR TITLE
Use utf-8 encoding for reading files

### DIFF
--- a/swift_domain/indexer.py
+++ b/swift_domain/indexer.py
@@ -178,7 +178,8 @@ class SwiftFileIndex(object):
             print("Indexing swift file: %s" % file)
             symbol_stack = []
             braces = 0
-            with open(file, "r") as fp:
+            with open(file, "r",encoding="utf-8") as fp:
+
                 content = fp.readlines()
                 for (index, line) in enumerate(content):
                     braces = balance_braces(line, braces)


### PR DESCRIPTION
When files have unicode characters, on OSX, the following error can occur

```
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/cmdline.py", line 243, in main
    opts.warningiserror, opts.tags, opts.verbosity, opts.jobs)
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 204, in __init__
    self._init_builder(self.buildername)
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 280, in _init_builder
    self.emit('builder-inited')
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 552, in emit
    results.append(callback(self, *args))
  File "/Users/drew/Code/anarchy_sphinx/swift_domain/swift.py", line 585, in make_index
    build_index(app)
  File "/Users/drew/Code/anarchy_sphinx/swift_domain/autodoc.py", line 12, in build_index
    file_index = SwiftFileIndex(app.config.swift_search_path)
  File "/Users/drew/Code/anarchy_sphinx/swift_domain/indexer.py", line 182, in __init__
    content = fp.readlines()
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1900: ordinal not in range(128)
```

In practice, my Swift files are utf-8 encoded and this resolves the issue
